### PR TITLE
fix: 학습 자료 업로드 토큰 제한 관련 로직 수행에 따른 수정사항 반영(다음 브랜치에서 실제 해결 진행)

### DIFF
--- a/libs/note-sdk/note_sdk/parsing/extractor.py
+++ b/libs/note-sdk/note_sdk/parsing/extractor.py
@@ -138,20 +138,9 @@ AI algorithms, robotics, smart devices
         )
         return answer
     except RateLimitError as e:
-        logger.error(f"[ImageEntityExtractor] Rate limit exceeded: {str(e)}")
-        update_progress(
-            space_id=data_batches[0].get("space_id"),
-            progress=-1,
-            status={
-                "status": "error",
-                "error": {
-                    "code": "FILE_413_2",
-                    "reason": "파일(PDF)의 이미지 토큰값 허용 범위 초과입니다.",
-                    "http_status": 413
-                }
-            }
-        )
-        return []  # 빈 리스트 반환
+        # Rate limit 에러는 로그만 남기고 계속 진행
+        logger.warning(f"[ImageEntityExtractor] Rate limit exceeded: {str(e)}")
+        return []  # 빈 리스트 반환하고 계속 진행
     except Exception as e:
         logger.error(f"[ImageEntityExtractor] Image processing error: {str(e)}")
         update_progress(

--- a/services/note-service/note_service/service.py
+++ b/services/note-service/note_service/service.py
@@ -70,16 +70,14 @@ class NoteService:
     async def update_progress(self, stage: str, status: str, result: Dict = None):
         if stage in self.progress_stages:
             progress = self.progress_stages[stage]
-            # 진행률이 증가하는 경우에만 업데이트
             if progress > self.current_progress:  
                 self.current_progress = progress
                 update_progress(self.space_id, self.current_progress, {
                     "status": status,
                     "result": result or {"spaceId": self.space_id}
                 })
-                # 진행률 표시를 위한 딜레이
-                await asyncio.sleep(0.5)
-                
+                # 딜레이 줄이기
+                await asyncio.sleep(0.1)  # 0.5초에서 0.1초로 줄임
 
     async def process_document(self) -> Dict[str, Any]:
         try:


### PR DESCRIPTION
## ⚠️ 연관된 이슈 번호 
<!-- 이슈번호를 작성해주세요 e.g. close #11 -->
- close #49 

## 📋 작업 내용 
<!-- 이번 PR에서 작업한 내용을 꼼꼼하게 작성하기! -->
- 학습 자료 업로드 과정에서 진행하는 파싱 로직은 Upstage의 Document Parsing API를 사용합니다. 이는 외부 API가 블로킹이기 때문에  파일이 대용량일 경우 SSE 과정에서 기본값인 45초를 넘었을 경우 연결이 끊기는 현상이 발생합니다. 
- 다음 이슈에서 Upstage API를 스트림으로 변경하여 이를 해결할 예정입니다. 

## 💬 리뷰 요구사항(선택) 
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요! -->

## 📷 스크린샷(선택)